### PR TITLE
Update to arrays.scala

### DIFF
--- a/static/extern/compiler/src/Arrays.scala
+++ b/static/extern/compiler/src/Arrays.scala
@@ -127,6 +127,8 @@ trait ForgeArrayBufferOpsExp extends DeliteArrayBufferOpsExp {
 
   def array_buffer_empty[T:Manifest](__arg0: Rep[Int])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
     = darray_buffer_new[T](__arg0)
+  def array_buffer_immutable[T:Manifest](__arg0: Rep[ForgeArrayBuffer[T]])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
+    = darray_buffer_immutable[T](__arg0)
   def array_buffer_strict_empty[T:Manifest](__arg0: Rep[Int])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
     = darray_buffer_new[T](__arg0,__arg0)
   def array_buffer_new_imm[T:Manifest](__arg0: Rep[ForgeArray[T]])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]

--- a/static/extern/library/src/Arrays.scala
+++ b/static/extern/library/src/Arrays.scala
@@ -72,6 +72,8 @@ trait ForgeArrayBufferWrapper extends HUMAN_DSL_NAMEBase {
 
   def array_buffer_empty[T:Manifest](__arg0: Rep[Int])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
     = new scala.collection.mutable.ArrayBuffer[T]()
+  def array_buffer_immutable[T:Manifest](__arg0: Rep[ForgeArrayBuffer[T]])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
+    = __arg0 
   def array_buffer_strict_empty[T:Manifest](__arg0: Rep[Int])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
     = (new scala.collection.mutable.ArrayBuffer[T]()) ++ (new Array[T](__arg0))
   def array_buffer_new_imm[T:Manifest](__arg0: Rep[ForgeArray[T]])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]

--- a/static/extern/shared/src/Arrays.scala
+++ b/static/extern/shared/src/Arrays.scala
@@ -76,6 +76,7 @@ trait ForgeArrayBufferCompilerOps extends ForgeArrayBufferOps {
   this: ForgeArrayCompilerOps =>
 
   def array_buffer_empty[T:Manifest](__arg0: Rep[Int])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
+  def array_buffer_immutable[T:Manifest](__arg0: Rep[ForgeArrayBuffer[T]])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
   def array_buffer_strict_empty[T:Manifest](__arg0: Rep[Int])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
   def array_buffer_new_imm[T:Manifest](__arg0: Rep[ForgeArray[T]])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]]
   def array_buffer_raw_alloc[T:Manifest](__arg0: Rep[ForgeArrayBuffer[T]],__arg1: Rep[Int])(implicit __imp0: SourceContext): Rep[ForgeArrayBuffer[T]] = array_buffer_empty[T](__arg1)


### PR DESCRIPTION
Updated the parallel ops available for both arrays and array buffers.  Fixed discrepancies between array buffer library and Delite generated code so that both run in the same fashion.
