### PR TITLE
Do not depend on FORGE_HOME

### DIFF
--- a/project/project/Build.scala
+++ b/project/project/Build.scala
@@ -2,6 +2,6 @@ import sbt._
 object PluginDef extends Build {
   lazy val root = Project("plugins", file(".")) dependsOn(preprocessor)
 
-  lazy val FORGE_HOME = sys.env.get("FORGE_HOME").getOrElse(error("Please set the FORGE_HOME environment variable"))
+  lazy val FORGE_HOME = ".."
   lazy val preprocessor = file(FORGE_HOME + "/preprocessor/")
 }


### PR DESCRIPTION
Enable loading of the project to IntelliJ without requiring system-wide "FORGE_HOME" environment variable to be set